### PR TITLE
Fix hallucinated LDraw library download URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ mkdir -p data/downloads data/ldraw
 
 For technical line drawings, download the LDraw parts library:
 
-1. Visit https://www.ldraw.org/library/updates/complete.zip
+1. Visit https://library.ldraw.org/library/updates/complete.zip
 2. Download the complete library
 3. Extract to `data/ldraw/`
    - Should contain folders like `parts/`, `p/`, etc.

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -93,7 +93,7 @@ For SVG line drawings instead of Rebrickable images:
 
 ### 1. Download LDraw Library
 
-Visit https://www.ldraw.org/library/updates/complete.zip
+Visit https://library.ldraw.org/library/updates/complete.zip
 
 This is the complete LDraw parts library (~50MB).
 


### PR DESCRIPTION
The correct URL for the complete LDraw library is: https://library.ldraw.org/library/updates/complete.zip

Changed from incorrect www.ldraw.org to library.ldraw.org