### PR TITLE
Enable multiple parts per slot (fixes #12)

### DIFF
--- a/database/schema.js
+++ b/database/schema.js
@@ -44,17 +44,30 @@ function initializeDatabase(dbPath = './data/lego-parts.db') {
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       bin_id TEXT NOT NULL,
       slot_number INTEGER NOT NULL,
-      part_num TEXT,
-      quantity INTEGER DEFAULT 0,
-      notes TEXT,
       updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
       FOREIGN KEY (bin_id) REFERENCES bins(bin_id),
-      FOREIGN KEY (part_num) REFERENCES parts(part_num),
       UNIQUE(bin_id, slot_number)
     );
 
     CREATE INDEX IF NOT EXISTS idx_slots_bin ON slots(bin_id);
-    CREATE INDEX IF NOT EXISTS idx_slots_part ON slots(part_num);
+  `);
+
+  // Create slot_parts table (allows multiple parts per slot)
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS slot_parts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      slot_id INTEGER NOT NULL,
+      part_num TEXT NOT NULL,
+      quantity INTEGER DEFAULT 0,
+      notes TEXT,
+      added_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (slot_id) REFERENCES slots(id) ON DELETE CASCADE,
+      FOREIGN KEY (part_num) REFERENCES parts(part_num),
+      UNIQUE(slot_id, part_num)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_slot_parts_slot ON slot_parts(slot_id);
+    CREATE INDEX IF NOT EXISTS idx_slot_parts_part ON slot_parts(part_num);
   `);
 
   // Create table for cached SVG line drawings

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node server.js",
     "dev": "nodemon server.js",
     "import-data": "node scripts/import-rebrickable.js",
+    "migrate": "node scripts/migrate-multiple-parts.js",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",

--- a/public/js/api/partsApi.js
+++ b/public/js/api/partsApi.js
@@ -44,24 +44,39 @@ export class PartsAPI {
   }
 
   // Slots endpoints
-  static async createSlot(binId, slotNumber, partNum = null, quantity = 0, notes = '') {
+  static async createSlot(binId, slotNumber) {
     return this.request('/api/slots', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ bin_id: binId, slot_number: slotNumber, part_num: partNum, quantity, notes })
-    });
-  }
-
-  static async updateSlot(slotId, partNum, quantity, notes) {
-    return this.request(`/api/slots/${slotId}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ part_num: partNum, quantity, notes })
+      body: JSON.stringify({ bin_id: binId, slot_number: slotNumber })
     });
   }
 
   static async deleteSlot(slotId) {
     return this.request(`/api/slots/${slotId}`, {
+      method: 'DELETE'
+    });
+  }
+
+  // Slot parts endpoints (for managing parts within a slot)
+  static async addPartToSlot(slotId, partNum, quantity = 0, notes = '') {
+    return this.request(`/api/slots/${slotId}/parts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ part_num: partNum, quantity, notes })
+    });
+  }
+
+  static async updateSlotPart(slotId, partId, quantity, notes) {
+    return this.request(`/api/slots/${slotId}/parts/${partId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ quantity, notes })
+    });
+  }
+
+  static async removePartFromSlot(slotId, partId) {
+    return this.request(`/api/slots/${slotId}/parts/${partId}`, {
       method: 'DELETE'
     });
   }

--- a/public/js/components/modals/AssignPartModal.js
+++ b/public/js/components/modals/AssignPartModal.js
@@ -44,17 +44,23 @@ export class AssignPartModal extends Modal {
     }
 
     try {
-      if (this.currentSlot.slotId) {
-        await PartsAPI.updateSlot(this.currentSlot.slotId, partNum, quantity, notes);
-      } else {
-        await PartsAPI.createSlot(
+      // Always add a part to the slot (creates slot if it doesn't exist)
+      if (!this.currentSlot.slotId) {
+        // Create the slot first
+        const result = await PartsAPI.createSlot(
           this.currentSlot.binId,
-          this.currentSlot.slotNumber,
-          partNum,
-          quantity,
-          notes
+          this.currentSlot.slotNumber
         );
+        this.currentSlot.slotId = result.id;
       }
+
+      // Add the part to the slot
+      await PartsAPI.addPartToSlot(
+        this.currentSlot.slotId,
+        partNum,
+        quantity,
+        notes
+      );
 
       this.close();
       this.emit('part-assigned', { binId: this.currentSlot.binId });

--- a/public/js/components/ui/SlotCard.js
+++ b/public/js/components/ui/SlotCard.js
@@ -3,7 +3,8 @@ import { html } from 'lit-html';
 
 export class SlotCard {
   static render(slot) {
-    const filled = slot.part_num ? 'filled' : 'empty';
+    const hasParts = slot.parts && slot.parts.length > 0;
+    const filled = hasParts ? 'filled' : 'empty';
 
     return html`
       <div class="slot-card ${filled}"
@@ -16,11 +17,26 @@ export class SlotCard {
                 title="Remove slot">×</button>
         <div class="slot-number">Slot ${slot.slot_number}</div>
         <div class="slot-content">
-          ${slot.part_num ? html`
-            <div class="part-num">${slot.part_num}</div>
-            <div class="part-name">${slot.part_name || 'Unknown part'}</div>
-            ${slot.quantity ? html`<div class="quantity">Qty: ${slot.quantity}</div>` : ''}
-            ${slot.notes ? html`<div class="notes"><small>${slot.notes}</small></div>` : ''}
+          ${hasParts ? html`
+            <div class="slot-parts-list">
+              ${slot.parts.map(part => html`
+                <div class="slot-part-item">
+                  <button class="remove-part-btn"
+                          data-action="remove-part"
+                          data-slot-id="${slot.id}"
+                          data-part-id="${part.id}"
+                          title="Remove this part">×</button>
+                  <div class="part-num">${part.part_num}</div>
+                  <div class="part-name">${part.part_name || 'Unknown part'}</div>
+                  ${part.quantity ? html`<div class="quantity">Qty: ${part.quantity}</div>` : ''}
+                  ${part.notes ? html`<div class="notes"><small>${part.notes}</small></div>` : ''}
+                </div>
+              `)}
+            </div>
+            <button class="add-another-part-btn"
+                    data-action="add-another-part"
+                    data-slot-id="${slot.id}"
+                    data-slot-number="${slot.slot_number}">+ Add Another Part</button>
           ` : html`<div>Empty - Click to assign</div>`}
         </div>
       </div>

--- a/public/js/components/views/BinsView.js
+++ b/public/js/components/views/BinsView.js
@@ -28,7 +28,7 @@ export class BinsView extends Component {
       }
 
       const assignPartBtn = e.target.closest('[data-action="assign-part"]');
-      if (assignPartBtn && !e.target.closest('[data-action="delete-slot"]')) {
+      if (assignPartBtn && !e.target.closest('[data-action="delete-slot"]') && !e.target.closest('[data-action="remove-part"]') && !e.target.closest('[data-action="add-another-part"]')) {
         const slotId = assignPartBtn.dataset.slotId;
         const slotNumber = assignPartBtn.dataset.slotNumber;
         this.emit('assign-part-requested', {
@@ -36,6 +36,28 @@ export class BinsView extends Component {
           slotNumber: parseInt(slotNumber),
           slotId: parseInt(slotId)
         });
+        return;
+      }
+
+      const addAnotherPartBtn = e.target.closest('[data-action="add-another-part"]');
+      if (addAnotherPartBtn) {
+        e.stopPropagation();
+        const slotId = addAnotherPartBtn.dataset.slotId;
+        const slotNumber = addAnotherPartBtn.dataset.slotNumber;
+        this.emit('assign-part-requested', {
+          binId: this.currentBin,
+          slotNumber: parseInt(slotNumber),
+          slotId: parseInt(slotId)
+        });
+        return;
+      }
+
+      const removePartBtn = e.target.closest('[data-action="remove-part"]');
+      if (removePartBtn) {
+        e.stopPropagation();
+        const slotId = removePartBtn.dataset.slotId;
+        const partId = removePartBtn.dataset.partId;
+        await this.removePartFromSlot(parseInt(slotId), parseInt(partId));
         return;
       }
 
@@ -169,7 +191,7 @@ export class BinsView extends Component {
         : 0;
 
       for (let i = 1; i <= numSlots; i++) {
-        await PartsAPI.createSlot(this.currentBin, maxSlot + i, null, 0);
+        await PartsAPI.createSlot(this.currentBin, maxSlot + i);
       }
 
       await this.viewBinDetails(this.currentBin);
@@ -179,8 +201,22 @@ export class BinsView extends Component {
     }
   }
 
+  async removePartFromSlot(slotId, partId) {
+    if (!confirm('Are you sure you want to remove this part from the slot?')) {
+      return;
+    }
+
+    try {
+      await PartsAPI.removePartFromSlot(slotId, partId);
+      await this.viewBinDetails(this.currentBin);
+    } catch (error) {
+      console.error('Remove part error:', error);
+      alert('Error removing part');
+    }
+  }
+
   async removeSlot(slotId) {
-    if (!confirm('Are you sure you want to remove this slot?')) {
+    if (!confirm('Are you sure you want to remove this slot and all its parts?')) {
       return;
     }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -353,6 +353,72 @@ nav {
   font-style: italic;
 }
 
+/* Multiple parts per slot */
+.slot-parts-list {
+  margin-bottom: 10px;
+}
+
+.slot-part-item {
+  position: relative;
+  padding: 10px;
+  margin-bottom: 8px;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(0, 102, 204, 0.2);
+  border-radius: 4px;
+}
+
+.slot-part-item:last-child {
+  margin-bottom: 0;
+}
+
+.remove-part-btn {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  width: 20px;
+  height: 20px;
+  border: none;
+  background: var(--danger-color);
+  color: white;
+  border-radius: 50%;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.2s;
+  z-index: 5;
+}
+
+.slot-part-item:hover .remove-part-btn {
+  opacity: 1;
+}
+
+.remove-part-btn:hover {
+  background: #c82333;
+  transform: scale(1.1);
+}
+
+.add-another-part-btn {
+  width: 100%;
+  padding: 8px;
+  background: var(--success-color);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  transition: background 0.2s;
+  margin-top: 5px;
+}
+
+.add-another-part-btn:hover {
+  background: #218838;
+}
+
 /* Labels */
 .labels-container {
   margin-top: 20px;

--- a/scripts/migrate-multiple-parts.js
+++ b/scripts/migrate-multiple-parts.js
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+/**
+ * Migration script: Enable multiple parts per slot
+ *
+ * This script migrates the database schema to support multiple LEGO parts
+ * being stored in a single slot. It creates a new slot_parts table and
+ * migrates existing data.
+ */
+
+const Database = require('better-sqlite3');
+const path = require('path');
+
+const dbPath = process.env.DB_PATH || './data/lego-parts.db';
+
+console.log('===========================================');
+console.log('Migration: Multiple Parts Per Slot');
+console.log('===========================================\n');
+
+try {
+  const db = new Database(dbPath);
+  console.log(`Connected to database: ${dbPath}`);
+
+  // Start transaction
+  db.exec('BEGIN TRANSACTION');
+
+  console.log('\n1. Creating new slot_parts table...');
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS slot_parts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      slot_id INTEGER NOT NULL,
+      part_num TEXT NOT NULL,
+      quantity INTEGER DEFAULT 0,
+      notes TEXT,
+      added_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (slot_id) REFERENCES slots(id) ON DELETE CASCADE,
+      FOREIGN KEY (part_num) REFERENCES parts(part_num),
+      UNIQUE(slot_id, part_num)
+    );
+  `);
+  console.log('   ✓ slot_parts table created');
+
+  // Create indexes for better performance
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_slot_parts_slot ON slot_parts(slot_id);
+    CREATE INDEX IF NOT EXISTS idx_slot_parts_part ON slot_parts(part_num);
+  `);
+  console.log('   ✓ Indexes created');
+
+  // Check if we need to migrate data
+  const hasOldColumns = db.prepare(`
+    SELECT COUNT(*) as count
+    FROM pragma_table_info('slots')
+    WHERE name IN ('part_num', 'quantity', 'notes')
+  `).get().count;
+
+  if (hasOldColumns > 0) {
+    console.log('\n2. Migrating existing data...');
+
+    // Migrate existing slot assignments to the new table
+    const existingSlots = db.prepare(`
+      SELECT id, part_num, quantity, notes
+      FROM slots
+      WHERE part_num IS NOT NULL
+    `).all();
+
+    if (existingSlots.length > 0) {
+      const insertStmt = db.prepare(`
+        INSERT INTO slot_parts (slot_id, part_num, quantity, notes)
+        VALUES (?, ?, ?, ?)
+      `);
+
+      for (const slot of existingSlots) {
+        insertStmt.run(slot.id, slot.part_num, slot.quantity || 0, slot.notes);
+      }
+
+      console.log(`   ✓ Migrated ${existingSlots.length} part assignments`);
+    } else {
+      console.log('   ✓ No existing data to migrate');
+    }
+
+    console.log('\n3. Restructuring slots table...');
+
+    // Create new slots table without part-specific columns
+    db.exec(`
+      CREATE TABLE slots_new (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        bin_id TEXT NOT NULL,
+        slot_number INTEGER NOT NULL,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (bin_id) REFERENCES bins(bin_id),
+        UNIQUE(bin_id, slot_number)
+      );
+    `);
+
+    // Copy data to new table
+    db.exec(`
+      INSERT INTO slots_new (id, bin_id, slot_number, updated_at)
+      SELECT id, bin_id, slot_number, updated_at
+      FROM slots;
+    `);
+
+    // Drop old table and rename new one
+    db.exec('DROP TABLE slots');
+    db.exec('ALTER TABLE slots_new RENAME TO slots');
+
+    // Recreate indexes
+    db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_slots_bin ON slots(bin_id);
+    `);
+
+    console.log('   ✓ Slots table restructured');
+  } else {
+    console.log('\n2. Schema already migrated (skipping data migration)');
+  }
+
+  // Commit transaction
+  db.exec('COMMIT');
+
+  console.log('\n===========================================');
+  console.log('Migration completed successfully!');
+  console.log('===========================================\n');
+
+  db.close();
+  process.exit(0);
+
+} catch (error) {
+  console.error('\n❌ Migration failed:', error.message);
+  console.error('\nRolling back changes...');
+
+  try {
+    const db = new Database(dbPath);
+    db.exec('ROLLBACK');
+    db.close();
+    console.log('Rollback complete.');
+  } catch (rollbackError) {
+    console.error('Rollback failed:', rollbackError.message);
+  }
+
+  process.exit(1);
+}


### PR DESCRIPTION
This commit implements the ability to assign multiple LEGO parts to a
single slot, addressing issue #12. This provides users with greater
flexibility in organizing their parts and improves space efficiency.

Database Changes:
- Refactored database schema to use many-to-many relationship
- Created new `slot_parts` table to link slots to multiple parts
- Modified `slots` table to remove part-specific columns
- Added migration script to upgrade existing databases

Backend Changes:
- Updated all API endpoints to work with new schema structure
- Added new endpoints for managing parts within slots:
  * POST /api/slots/:slotId/parts - Add part to slot
  * PUT /api/slots/:slotId/parts/:partId - Update part in slot
  * DELETE /api/slots/:slotId/parts/:partId - Remove part from slot
- Modified search, bin details, and labels endpoints
- Maintained backward compatibility through migration

Frontend Changes:
- Updated SlotCard component to display multiple parts per slot
- Enhanced UI with individual remove buttons for each part
- Added "Add Another Part" button for easy multi-part assignment
- Updated AssignPartModal to add parts instead of replacing
- Added new event handlers in BinsView for part management
- Updated partsApi.js with new API methods

UI/UX Improvements:
- Added visual styling for multiple parts display
- Individual part items with hover-to-show remove buttons
- Clear visual separation between parts in the same slot
- Improved confirmation messages for destructive actions

Migration:
- Created migration script: scripts/migrate-multiple-parts.js
- Added npm script: `npm run migrate`
- Automatic data migration from old schema to new
- Transaction-based migration with rollback support

Documentation:
- Updated README with migration instructions
- Documented new API endpoints
- Updated database schema documentation
- Added feature description for multiple parts per slot